### PR TITLE
Move single-part upload to fargate task

### DIFF
--- a/app/ecs/upload_single_part_file/Dockerfile
+++ b/app/ecs/upload_single_part_file/Dockerfile
@@ -1,0 +1,72 @@
+FROM debian:bookworm
+
+ARG TARGETPLATFORM
+ARG CURL_VERSION="8.15.0"
+ARG WRAPICA_VERSION="2.38.0.dev20250818113956"
+ARG PYTHON_VERSION="3.12"
+
+RUN \
+  # Set the platform URL based on the TARGETPLATFORM argument
+  if [ "${TARGETPLATFORM#linux/}" = "arm64" ]; then \
+    platform_url="aarch64";  \
+  else \
+    platform_url="x86_64"; \
+  fi && \
+ # Standard setup
+ apt update -yq && \
+ apt upgrade -yq && \
+ # APT installations to build curl
+ apt install -yq \
+    wget \
+    tar \
+    jq \
+    unzip \
+    build-essential \
+    libssl-dev \
+    libpsl-dev && \
+  # Download and install the latest version of curl
+  wget --quiet \
+    "https://github.com/curl/curl/releases/download/curl-$(echo "${CURL_VERSION}" | sed 's/\./_/g')/curl-${CURL_VERSION}.tar.gz" && \
+  tar -xzf "curl-${CURL_VERSION}.tar.gz" && \
+  ( \
+    cd "curl-${CURL_VERSION}" && \
+    ./configure \
+      --prefix=/usr \
+      --with-openssl && \
+    make && \
+    make install && \
+    ldconfig \
+  ) && \
+  rm -rf "curl-${CURL_VERSION}" "curl-${CURL_VERSION}.tar.gz" && \
+  # Install uv
+  curl -LsSf https://astral.sh/uv/install.sh | XDG_CONFIG_HOME=/tmp UV_INSTALL_DIR=/usr/bin sh && \
+  uv venv --python "${PYTHON_VERSION}" && \
+  # Install wrapica \
+  uv pip install \
+    --index-url "https://pypi.org/simple" \
+    --extra-index-url "https://test.pypi.org/simple" \
+    --index-strategy unsafe-best-match \
+    wrapica=="${WRAPICA_VERSION}" && \
+  # Install the aws cli \
+  ( \
+      wget \
+        --quiet \
+        --output-document "awscliv2.zip" \
+        "https://awscli.amazonaws.com/awscli-exe-linux-${platform_url}.zip" && \
+      unzip -q "awscliv2.zip" && \
+      ./aws/install && \
+      rm -rf "awscliv2.zip" "aws" \
+  )
+
+
+# Install entrypoint script
+COPY docker-entrypoint.sh "docker-entrypoint.sh"
+
+# Install the scripts
+COPY scripts/ scripts/
+
+# Make the docker entrypoint executable
+RUN chmod +x "./docker-entrypoint.sh"
+
+# Set the entrypoint as the docker entrypoint script
+CMD [ "./docker-entrypoint.sh" ]

--- a/app/ecs/upload_single_part_file/docker-entrypoint.sh
+++ b/app/ecs/upload_single_part_file/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Quick function to log messages to stderr
+echo_stderr(){
+  echo "$(date -Iseconds)" "$@" >&2
+}
+
+# Confirm the following environment variables are set
+# ICAV2_ACCESS_TOKEN_SECRET_ID
+# SOURCE_PROJECT_ID
+# SOURCE_DATA_ID
+# DEST_PROJECT_ID
+# DEST_DATA_ID
+
+if [[ -z "${ICAV2_ACCESS_TOKEN_SECRET_ID:-}" ]]; then
+  echo_stderr "ICAV2_ACCESS_TOKEN_SECRET_ID is not set. Exiting."
+  exit 1
+fi
+
+if [[ -z "${SOURCE_PROJECT_ID:-}" ]]; then
+  echo_stderr "SOURCE_PROJECT_ID is not set. Exiting."
+  exit 1
+fi
+
+if [[ -z "${SOURCE_DATA_ID:-}" ]]; then
+  echo_stderr "SOURCE_DATA_ID is not set. Exiting."
+  exit 1
+fi
+
+if [[ -z "${DEST_PROJECT_ID:-}" ]]; then
+  echo_stderr "DEST_PROJECT_ID is not set. Exiting."
+  exit 1
+fi
+
+if [[ -z "${DEST_DATA_ID:-}" ]]; then
+  echo_stderr "DEST_DATA_ID is not set. Exiting."
+  exit 1
+fi
+
+# Set ICAV2_ACCESS_TOKEN environment variable
+ICAV2_ACCESS_TOKEN="$( \
+  aws secretsmanager get-secret-value \
+    --secret-id "${ICAV2_ACCESS_TOKEN_SECRET_ID}" \
+    --output json | \
+  jq --raw-output '.SecretString' \
+)"
+export ICAV2_ACCESS_TOKEN
+
+# Run the Python script
+uv run python3 scripts/upload_single_part_file.py \
+  --source-project-id "${SOURCE_PROJECT_ID}" \
+  --source-data-id "${SOURCE_DATA_ID}" \
+  --dest-project-id "${DEST_PROJECT_ID}" \
+  --dest-data-id "${DEST_DATA_ID}"

--- a/app/ecs/upload_single_part_file/scripts/upload_single_part_file.py
+++ b/app/ecs/upload_single_part_file/scripts/upload_single_part_file.py
@@ -63,6 +63,8 @@ from wrapica.project_data import (
 )
 from wrapica.utils.globals import FILE_DATA_TYPE
 
+# Globals
+POST_DELETION_WAIT_TIME = 5  # seconds, time to wait after deleting a file before trying to upload again
 
 def get_shell_script_template() -> str:
     return dedent(
@@ -221,7 +223,7 @@ def main():
                 data_id=existing_project_data_obj.data.id
             )
             # Wait for the db to catch up
-            sleep(5)
+            sleep(POST_DELETION_WAIT_TIME)
         elif existing_project_data_obj.data.details.file_size_in_bytes == source_object.data.details.file_size_in_bytes:
             # If the file sizes match, we can skip the upload
             # Check the file sizes match

--- a/app/step-function-templates/handle_copy_jobs_sfn_template.asl.json
+++ b/app/step-function-templates/handle_copy_jobs_sfn_template.asl.json
@@ -96,30 +96,53 @@
                         "States": {
                           "Upload Single File": {
                             "Type": "Task",
-                            "Resource": "arn:aws:states:::lambda:invoke",
-                            "Output": "{% $states.result.Payload %}",
+                            "Resource": "arn:aws:states:::ecs:runTask.sync",
                             "Arguments": {
-                              "FunctionName": "${__upload_single_part_file_lambda_function_arn__}",
-                              "Payload": {
-                                "sourceData": "{% $states.input.sourceDataIter %}",
-                                "destinationData": "{% $states.input.destinationDataIter %}"
+                              "LaunchType": "FARGATE",
+                              "Cluster": "${__cluster__}",
+                              "TaskDefinition": "${__task_definition__}",
+                              "NetworkConfiguration": {
+                                "AwsvpcConfiguration": {
+                                  "Subnets": "{% $split('${__subnets__}', ',') %}",
+                                  "SecurityGroups": "{% [ '${__security_group__}' ] %}"
+                                }
+                              },
+                              "Overrides": {
+                                "ContainerOverrides": [
+                                  {
+                                    "Name": "${__container_name__}",
+                                    "Environment": [
+                                      {
+                                        "Name": "SOURCE_PROJECT_ID",
+                                        "Value": "{% $states.input.sourceDataIter.projectId %}"
+                                      },
+                                      {
+                                        "Name": "SOURCE_DATA_ID",
+                                        "Value": "{% $states.input.sourceDataIter.dataId %}"
+                                      },
+                                      {
+                                        "Name": "DEST_PROJECT_ID",
+                                        "Value": "{% $states.input.destinationDataIter.projectId %}"
+                                      },
+                                      {
+                                        "Name": "DEST_DATA_ID",
+                                        "Value": "{% $states.input.destinationDataIter.dataId %}"
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             },
+                            "End": true,
                             "Retry": [
                               {
-                                "ErrorEquals": [
-                                  "Lambda.ServiceException",
-                                  "Lambda.AWSLambdaException",
-                                  "Lambda.SdkClientException",
-                                  "Lambda.TooManyRequestsException"
-                                ],
-                                "IntervalSeconds": 1,
-                                "MaxAttempts": 3,
+                                "ErrorEquals": ["ECS.AmazonECSException"],
                                 "BackoffRate": 2,
+                                "IntervalSeconds": 20,
+                                "MaxAttempts": 3,
                                 "JitterStrategy": "FULL"
                               }
-                            ],
-                            "End": true
+                            ]
                           }
                         }
                       },

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,82 @@
+{
+  "vpc-provider:account=472057503814:filter.tag:Name=main-vpc:region=ap-southeast-2:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-0dc99f521ceaa3f2d",
+    "vpcCidrBlock": "10.2.0.0/16",
+    "ownerAccountId": "472057503814",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-0a7fb9d501192f5ee",
+            "cidr": "10.2.0.0/23",
+            "availabilityZone": "ap-southeast-2a",
+            "routeTableId": "rtb-0c10b927ab0264377"
+          },
+          {
+            "subnetId": "subnet-0d61be977ee60a5b5",
+            "cidr": "10.2.2.0/23",
+            "availabilityZone": "ap-southeast-2b",
+            "routeTableId": "rtb-0c10b927ab0264377"
+          },
+          {
+            "subnetId": "subnet-0d8226a9b4af34507",
+            "cidr": "10.2.4.0/23",
+            "availabilityZone": "ap-southeast-2c",
+            "routeTableId": "rtb-0c10b927ab0264377"
+          }
+        ]
+      },
+      {
+        "name": "database",
+        "type": "Isolated",
+        "subnets": [
+          {
+            "subnetId": "subnet-03ac51c3ab4223a1a",
+            "cidr": "10.2.40.0/23",
+            "availabilityZone": "ap-southeast-2a",
+            "routeTableId": "rtb-01266550d60b56ddb"
+          },
+          {
+            "subnetId": "subnet-06d14dcb934f22c5e",
+            "cidr": "10.2.42.0/23",
+            "availabilityZone": "ap-southeast-2b",
+            "routeTableId": "rtb-01266550d60b56ddb"
+          },
+          {
+            "subnetId": "subnet-0f5a5386ddf295579",
+            "cidr": "10.2.44.0/23",
+            "availabilityZone": "ap-southeast-2c",
+            "routeTableId": "rtb-01266550d60b56ddb"
+          }
+        ]
+      },
+      {
+        "name": "private",
+        "type": "Private",
+        "subnets": [
+          {
+            "subnetId": "subnet-01be4c1109eca3446",
+            "cidr": "10.2.20.0/23",
+            "availabilityZone": "ap-southeast-2a",
+            "routeTableId": "rtb-067d123217c80f6bd"
+          },
+          {
+            "subnetId": "subnet-070a9acba78168239",
+            "cidr": "10.2.22.0/23",
+            "availabilityZone": "ap-southeast-2b",
+            "routeTableId": "rtb-067d123217c80f6bd"
+          },
+          {
+            "subnetId": "subnet-01ae2b4ad1eb584d7",
+            "cidr": "10.2.24.0/23",
+            "availabilityZone": "ap-southeast-2c",
+            "routeTableId": "rtb-067d123217c80f6bd"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -7,6 +7,7 @@ import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accoun
 export const APP_ROOT = path.join(__dirname, '../../app');
 export const LAMBDA_DIR = path.join(APP_ROOT, 'lambdas');
 export const STEP_FUNCTIONS_DIR = path.join(APP_ROOT, 'step-function-templates');
+export const ECS_DIR = path.join(APP_ROOT, 'ecs');
 
 /* Internal event bus constants */
 export const INTERNAL_EVENT_BUS_DESCRIPTION =

--- a/infrastructure/stage/ecs/index.ts
+++ b/infrastructure/stage/ecs/index.ts
@@ -28,7 +28,8 @@ export function buildUploadSinglePartFileFargateTask(
   /*
     Build the Upload SinglePart File Fargate task.
 
-    We use 8 CPUs for this task, as we want the network speed up and the gzip will use the threads.
+    We use 2 CPUs for this task but we need a large amount of memory
+    Since curl downloads and stored in memory and THEN uploads to S3 from memory
     The containerName will be set to 'upload-single-part-file-task'
     and the docker path can be found under ECS_DIR / 'ora_decompression'
     */

--- a/infrastructure/stage/ecs/index.ts
+++ b/infrastructure/stage/ecs/index.ts
@@ -1,0 +1,78 @@
+/*
+Build the ecs fargate task
+*/
+
+import { Construct } from 'constructs';
+import {
+  CPU_ARCHITECTURE_MAP,
+  EcsFargateTaskConstruct,
+  FargateEcsTaskConstructProps,
+} from '@orcabus/platform-cdk-constructs/ecs';
+import * as path from 'path';
+import { ECS_DIR } from '../constants';
+import { BuildUploadSinglePartFileFargateEcsProps } from './interfaces';
+import { NagSuppressions } from 'cdk-nag';
+import { ICAV2_BASE_URL } from '@orcabus/platform-cdk-constructs/shared-config/icav2';
+
+function buildEcsFargateTask(scope: Construct, id: string, props: FargateEcsTaskConstructProps) {
+  /*
+    Generate an ECS Fargate task construct with the provided properties.
+    */
+  return new EcsFargateTaskConstruct(scope, id, props);
+}
+
+export function buildUploadSinglePartFileFargateTask(
+  scope: Construct,
+  props: BuildUploadSinglePartFileFargateEcsProps
+): EcsFargateTaskConstruct {
+  /*
+    Build the Upload SinglePart File Fargate task.
+
+    We use 8 CPUs for this task, as we want the network speed up and the gzip will use the threads.
+    The containerName will be set to 'upload-single-part-file-task'
+    and the docker path can be found under ECS_DIR / 'ora_decompression'
+    */
+
+  const ecsTask = buildEcsFargateTask(scope, 'UploadSinglePartFileFargateTask', {
+    containerName: 'upload-single-part-file-task',
+    dockerPath: path.join(ECS_DIR, 'upload_single_part_file'),
+    nCpus: 2, // 2 CPUs
+    memoryLimitGiB: 16, // 16 GB of memory (maximum for 2 CPUs)
+    architecture: 'ARM64',
+    runtimePlatform: CPU_ARCHITECTURE_MAP['ARM64'],
+  });
+
+  // Needs access to the secrets manager
+  props.icav2AccessTokenSecretObj.grantRead(ecsTask.taskDefinition.taskRole);
+
+  ecsTask.containerDefinition.addEnvironment(
+    'ICAV2_ACCESS_TOKEN_SECRET_ID',
+    props.icav2AccessTokenSecretObj.secretName
+  );
+  ecsTask.containerDefinition.addEnvironment('ICAV2_BASE_URL', ICAV2_BASE_URL);
+
+  // Add suppressions for the task role
+  // Since the task role needs to access the S3 bucket prefix
+  NagSuppressions.addResourceSuppressions(
+    [ecsTask.taskDefinition, ecsTask.taskExecutionRole],
+    [
+      {
+        id: 'AwsSolutions-IAM5',
+        reason: 'The task role needs to access secrets manager.',
+      },
+      {
+        id: 'AwsSolutions-IAM4',
+        reason:
+          'We use the standard ecs task role for this task, which allows the guard duty agent to run alongside the task.',
+      },
+      {
+        id: 'AwsSolutions-ECS2',
+        reason:
+          'The task is designed to run with some constant environment variables, not sure why this is a bad thing?',
+      },
+    ],
+    true
+  );
+
+  return ecsTask;
+}

--- a/infrastructure/stage/ecs/interfaces.ts
+++ b/infrastructure/stage/ecs/interfaces.ts
@@ -1,0 +1,9 @@
+/*
+Interfaces
+*/
+
+import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
+
+export interface BuildUploadSinglePartFileFargateEcsProps {
+  icav2AccessTokenSecretObj: ISecret;
+}

--- a/infrastructure/stage/lambda/index.ts
+++ b/infrastructure/stage/lambda/index.ts
@@ -28,7 +28,7 @@ function buildLambda(scope: Construct, props: BuildLambdaProps): LambdaObject {
     index: lambdaNameToSnakeCase + '.py',
     handler: 'handler',
     timeout: Duration.seconds(900),
-    memorySize: 2048,
+    memorySize: 2048, // 2GB
     includeIcav2Layer: lambdaRequirements.needsIcav2AccessToken,
   });
 

--- a/infrastructure/stage/lambda/interfaces.ts
+++ b/infrastructure/stage/lambda/interfaces.ts
@@ -6,7 +6,6 @@ export type LambdaNameList =
   | 'convertSourceUriFolderToUriList'
   | 'generateCopyJobList'
   | 'launchIcav2Copy'
-  | 'uploadSinglePartFile'
   | 'checkJobStatus';
 
 /* Lambda names array */
@@ -16,7 +15,6 @@ export const lambdaNameList: Array<LambdaNameList> = [
   'convertSourceUriFolderToUriList',
   'generateCopyJobList',
   'launchIcav2Copy',
-  'uploadSinglePartFile',
   'checkJobStatus',
 ];
 
@@ -38,9 +36,6 @@ export const lambdaToRequirementsMap: LambdaToRequirementsMapType = {
     needsIcav2AccessToken: true,
   },
   launchIcav2Copy: {
-    needsIcav2AccessToken: true,
-  },
-  uploadSinglePartFile: {
     needsIcav2AccessToken: true,
   },
   checkJobStatus: {

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -4,6 +4,7 @@ import { LambdaNameList, LambdaObject } from '../lambda/interfaces';
 import { EventBridgeNameList } from '../event-rules/interfaces';
 import { IEventBus } from 'aws-cdk-lib/aws-events';
 import { ITableV2 } from 'aws-cdk-lib/aws-dynamodb';
+import { EcsFargateTaskConstruct } from '@orcabus/platform-cdk-constructs/ecs';
 
 export type SfnNameList =
   | 'handleCopyJobs'
@@ -24,7 +25,6 @@ export interface SfnObject extends SfnProps {
 export const HandleCopyJobsLambdaList: Array<LambdaNameList> = [
   'generateCopyJobList',
   'launchIcav2Copy',
-  'uploadSinglePartFile',
   'findSinglePartFiles',
   'convertSourceUriFolderToUriList',
 ];
@@ -46,6 +46,9 @@ export interface SfnRequirementsProps {
   needsInternalEventBus?: boolean;
   needsIcav2CopyServiceEventSource?: boolean;
   needsIcav2CopyServiceDetailType?: boolean;
+
+  /* ECS Stuff */
+  needsEcsPermissions?: boolean;
 
   /* Does the Step Function need table access bus */
   needsTableObj?: boolean;
@@ -70,6 +73,9 @@ export const SfnRequirementsMapType: { [key in SfnNameList]: SfnRequirementsProp
     needsInternalEventBus: true,
     needsIcav2CopyServiceEventSource: true,
     needsIcav2CopyServiceDetailType: true,
+
+    /* ECS Stuff */
+    needsEcsPermissions: true,
 
     /* Task Token permissions */
     needsTaskTokenUpdatePermissions: true,
@@ -120,21 +126,8 @@ export interface BuildSfnProps extends SfnProps {
   icav2CopyServiceEventSource?: string;
   icav2CopyServiceDetailType?: string;
 
-  /* Table stuff */
-  tableObj?: ITableV2;
-
-  /* Event Bridge Stuff */
-  heartBeatRuleName?: heartBeatRuleNameList;
-}
-
-export interface BuildSfnsProps {
-  /* Lambdas */
-  lambdas?: LambdaObject[];
-
-  /* Event Stuff */
-  internalEventBus?: IEventBus;
-  icav2CopyServiceEventSource?: string;
-  icav2CopyServiceDetailType?: string;
+  /* ECS Stuff */
+  uploadSinglePartFileEcsFargateObject: EcsFargateTaskConstruct;
 
   /* Table stuff */
   tableObj?: ITableV2;
@@ -142,6 +135,8 @@ export interface BuildSfnsProps {
   /* Event Bridge Stuff */
   heartBeatRuleName?: heartBeatRuleNameList;
 }
+
+export type BuildSfnsProps = Omit<BuildSfnProps, 'stateMachineName'>;
 
 export interface WirePermissionsProps extends BuildSfnProps {
   stateMachineObj: StateMachine;

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "organization": true
   },
   "license": "MIT",
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
   "devDependencies": {
-    "@eslint/js": "^9.32.0",
+    "@eslint/js": "^9.33.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.17.0",
-    "aws-cdk": "^2.1023.0",
-    "cdk-nag": "^2.36.50",
-    "eslint": "^9.32.0",
+    "@types/node": "^22.17.2",
+    "aws-cdk": "^2.1025.0",
+    "cdk-nag": "^2.37.6",
+    "eslint": "^9.33.0",
     "globals": "^16.3.0",
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
@@ -35,14 +35,14 @@
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.38.0"
+    "typescript-eslint": "^8.40.0"
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.208.0-alpha.0",
     "@aws-cdk/aws-pipes-alpha": "2.208.0-alpha.0",
     "@aws-cdk/aws-pipes-sources-alpha": "2.208.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "0.0.57",
-    "aws-cdk-lib": "^2.208.0",
+    "@orcabus/platform-cdk-constructs": "0.0.64",
+    "aws-cdk-lib": "^2.211.0",
     "constructs": "^10.4.2",
     "sqs-dlq-monitoring": "^1.2.21",
     "uv-python-lambda": "^0.0.7"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aws-cdk/aws-lambda-python-alpha": "2.208.0-alpha.0",
     "@aws-cdk/aws-pipes-alpha": "2.208.0-alpha.0",
     "@aws-cdk/aws-pipes-sources-alpha": "2.208.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "0.0.64",
+    "@orcabus/platform-cdk-constructs": "0.0.66",
     "aws-cdk-lib": "^2.211.0",
     "constructs": "^10.4.2",
     "sqs-dlq-monitoring": "^1.2.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,53 +10,53 @@ importers:
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha':
         specifier: 2.208.0-alpha.0
-        version: 2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       '@aws-cdk/aws-pipes-alpha':
         specifier: 2.208.0-alpha.0
-        version: 2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       '@aws-cdk/aws-pipes-sources-alpha':
         specifier: 2.208.0-alpha.0
-        version: 2.208.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.208.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       '@orcabus/platform-cdk-constructs':
-        specifier: 0.0.57
-        version: 0.0.57(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: 0.0.64
+        version: 0.0.64(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
-        specifier: ^2.208.0
-        version: 2.208.0(constructs@10.4.2)
+        specifier: ^2.211.0
+        version: 2.211.0(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
       sqs-dlq-monitoring:
         specifier: ^1.2.21
-        version: 1.2.21(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 1.2.21(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       uv-python-lambda:
         specifier: ^0.0.7
-        version: 0.0.7(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.0.7(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
     devDependencies:
       '@eslint/js':
-        specifier: ^9.32.0
-        version: 9.32.0
+        specifier: ^9.33.0
+        version: 9.33.0
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^22.17.0
-        version: 22.17.0
+        specifier: ^22.17.2
+        version: 22.17.2
       aws-cdk:
-        specifier: ^2.1023.0
-        version: 2.1023.0
+        specifier: ^2.1025.0
+        version: 2.1025.0
       cdk-nag:
-        specifier: ^2.36.50
-        version: 2.36.50(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^2.37.6
+        version: 2.37.6(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       eslint:
-        specifier: ^9.32.0
-        version: 9.32.0
+        specifier: ^9.33.0
+        version: 9.33.0
       globals:
         specifier: ^16.3.0
         version: 16.3.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+        version: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -65,16 +65,16 @@ importers:
         version: 0.0.4
       ts-jest:
         specifier: ^29.4.1
-        version: 29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)))(typescript@5.9.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.17.0)(typescript@5.9.2)
+        version: 10.9.2(@types/node@22.17.2)(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       typescript-eslint:
-        specifier: ^8.38.0
-        version: 8.38.0(eslint@9.32.0)(typescript@5.9.2)
+        specifier: ^8.40.0
+        version: 8.40.0(eslint@9.33.0)(typescript@5.9.2)
 
 packages:
 
@@ -110,8 +110,8 @@ packages:
       aws-cdk-lib: ^2.208.0
       constructs: ^10.0.0
 
-  '@aws-cdk/cloud-assembly-schema@45.2.0':
-    resolution: {integrity: sha512-5TTUkGHQ+nfuUGwKA8/Yraxb+JdNUh4np24qk/VHXmrCMq+M6HfmGWfhcg/QlHA2S5P3YIamfYHdQAB4uSNLAg==}
+  '@aws-cdk/cloud-assembly-schema@48.4.0':
+    resolution: {integrity: sha512-pWk5oucfA4Ywt0g5sjr8uABzTBNBrMfxVkHqc7b9jUYlMoY9CzCiOAcCdVLaqrtFp63a+z0M4s1sf6gaIkbeaA==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -125,12 +125,12 @@ packages:
     resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.0':
-    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
+  '@babel/core@7.28.3':
+    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.0':
-    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.27.2':
@@ -145,8 +145,8 @@ packages:
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.27.3':
-    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -167,12 +167,12 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.2':
-    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
+  '@babel/helpers@7.28.3':
+    resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.0':
-    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -271,8 +271,8 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.0':
-    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
+  '@babel/traverse@7.28.3':
+    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.2':
@@ -300,28 +300,28 @@ packages:
     resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.3.0':
-    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
+  '@eslint/config-helpers@0.3.1':
+    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.15.1':
-    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.32.0':
-    resolution: {integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==}
+  '@eslint/js@9.33.0':
+    resolution: {integrity: sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.3.4':
-    resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@humanfs/core@0.19.1':
@@ -418,18 +418,18 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jridgewell/gen-mapping@0.3.12':
-    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.4':
-    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.29':
-    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -446,8 +446,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@orcabus/platform-cdk-constructs@0.0.57':
-    resolution: {integrity: sha512-ejT+56lwUG1L5NQO61Xh0oYP/q8kKI/sW879/aPownBFhGgsmmiY3WA+otiYgtER0s8XGJWWlGvY3C0obNWWVw==}
+  '@orcabus/platform-cdk-constructs@0.0.64':
+    resolution: {integrity: sha512-itHdLe+0n7aP/SokDCgqzoCIWRmI6+dhFyyQQl43Z52uy4kKwHz1VBpihfmv9bhGHE0gRZc8LoR0l7HveSf7GA==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.208.0-alpha.0
       aws-cdk-lib: ^2.208.0
@@ -507,8 +507,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@22.17.0':
-    resolution: {integrity: sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==}
+  '@types/node@22.17.2':
+    resolution: {integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -519,63 +519,63 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@typescript-eslint/eslint-plugin@8.38.0':
-    resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
+  '@typescript-eslint/eslint-plugin@8.40.0':
+    resolution: {integrity: sha512-w/EboPlBwnmOBtRbiOvzjD+wdiZdgFeo17lkltrtn7X37vagKKWJABvyfsJXTlHe6XBzugmYgd4A4nW+k8Mixw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.38.0
+      '@typescript-eslint/parser': ^8.40.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.38.0':
-    resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/project-service@8.38.0':
-    resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/scope-manager@8.38.0':
-    resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.38.0':
-    resolution: {integrity: sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/type-utils@8.38.0':
-    resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
+  '@typescript-eslint/parser@8.40.0':
+    resolution: {integrity: sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.38.0':
-    resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.38.0':
-    resolution: {integrity: sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==}
+  '@typescript-eslint/project-service@8.40.0':
+    resolution: {integrity: sha512-/A89vz7Wf5DEXsGVvcGdYKbVM9F7DyFXj52lNYUDS1L9yJfqjW/fIp5PgMuEJL/KeqVTe2QSbXAGUZljDUpArw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.38.0':
-    resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
+  '@typescript-eslint/scope-manager@8.40.0':
+    resolution: {integrity: sha512-y9ObStCcdCiZKzwqsE8CcpyuVMwRouJbbSrNuThDpv16dFAj429IkM6LNb1dZ2m7hK5fHyzNcErZf7CEeKXR4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.40.0':
+    resolution: {integrity: sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.40.0':
+    resolution: {integrity: sha512-eE60cK4KzAc6ZrzlJnflXdrMqOBaugeukWICO2rB0KNvwdIMaEaYiywwHMzA1qFpTxrLhN9Lp4E/00EgWcD3Ow==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.38.0':
-    resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+  '@typescript-eslint/types@8.40.0':
+    resolution: {integrity: sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.40.0':
+    resolution: {integrity: sha512-k1z9+GJReVVOkc1WfVKs1vBrR5MIKKbdAjDTPvIK3L8De6KbFfPFt6BKpdkdk7rZS2GtC/m6yI5MYX+UsuvVYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.40.0':
+    resolution: {integrity: sha512-Cgzi2MXSZyAUOY+BFwGs17s7ad/7L+gKt6Y8rAVVWS+7o6wrjeFN4nVfTpbE25MNcxyJ+iYUXflbs2xR9h4UBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.40.0':
+    resolution: {integrity: sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -624,9 +624,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aws-cdk-lib@2.208.0:
-    resolution: {integrity: sha512-lZW475enKz36A/hZvS7xUwfjeqLqxKgBmZ2cGA7BB5PAlQsjBfN70ZGDgGl0egug5fb/hsYy1Dy4OrclfNzxFg==}
-    engines: {node: '>= 14.15.0'}
+  aws-cdk-lib@2.211.0:
+    resolution: {integrity: sha512-wrEPu25572HUJwySzL/qf/fFM+a22X7HYpq1uqcjAn4sVL+h52WjVjnI7rDAuhBp6efX6+Jhmw7jZDMql4/+Cw==}
+    engines: {node: '>= 18.0.0'}
     peerDependencies:
       constructs: ^10.0.0
     bundledDependencies:
@@ -642,8 +642,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.1023.0:
-    resolution: {integrity: sha512-DWMA+IrAsBUNF2RvH7ujpDp7wSJkqTkRL8yfK4AYpEjoGY1KMaKIfxz3M3+Nk3ogM7VhZiW3OGWEOgyDF47HOQ==}
+  aws-cdk@2.1025.0:
+    resolution: {integrity: sha512-qKYM+RG5+U/UbGpjTt8ZaxBEfKJMPdOmtPtFNidsIGlrdIWSIFdNcFYi13zo33FkMk6ZFA6yBnjfDry3fNR+hQ==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -685,8 +685,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.25.1:
-    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
+  browserslist@4.25.3:
+    resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -712,13 +712,13 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001731:
-    resolution: {integrity: sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==}
+  caniuse-lite@1.0.30001735:
+    resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
 
-  cdk-nag@2.36.50:
-    resolution: {integrity: sha512-c53NizlMWwvuErIR0qAoYOURHeNGFfyHvIesS0CDK+/z7JzHkCuDhzb9G+1sAlZdM0SobjLqD0AuCBOoIlqHTw==}
+  cdk-nag@2.37.6:
+    resolution: {integrity: sha512-0i9IwYfkXB/GpBfYmp6NI/pr6XxUberA0HEVsSMD8CYhOa8zBoUVCdntgTPU6G+7CO2Avs+uNG+JHELE3SowGA==}
     peerDependencies:
-      aws-cdk-lib: ^2.156.0
+      aws-cdk-lib: ^2.176.0
       constructs: ^10.0.5
 
   chalk@4.1.2:
@@ -811,8 +811,8 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
-  electron-to-chromium@1.5.194:
-    resolution: {integrity: sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==}
+  electron-to-chromium@1.5.204:
+    resolution: {integrity: sha512-s9VbBXWxfDrl67PlO4avwh0/GU2vcwx8Fph3wlR8LJl7ySGYId59EFE17VWVcuC3sLWNPENm6Z/uGqKbkPCcXA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -848,8 +848,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.32.0:
-    resolution: {integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==}
+  eslint@9.33.0:
+    resolution: {integrity: sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -1097,8 +1097,8 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
-  istanbul-reports@3.1.7:
-    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
   jest-changed-files@29.7.0:
@@ -1649,12 +1649,12 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typescript-eslint@8.38.0:
-    resolution: {integrity: sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==}
+  typescript-eslint@8.40.0:
+    resolution: {integrity: sha512-Xvd2l+ZmFDPEt4oj1QEXzA4A2uUK6opvKu3eGN9aGjB8au02lIVcLyi375w94hHyejTOmzIU77L8ol2sRg9n7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
+      typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -1744,30 +1744,30 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
 
   '@aws-cdk/asset-awscli-v1@2.2.242': {}
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  '@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  '@aws-cdk/aws-pipes-sources-alpha@2.208.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-pipes-sources-alpha@2.208.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      '@aws-cdk/aws-pipes-alpha': 2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      '@aws-cdk/aws-pipes-alpha': 2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  '@aws-cdk/cloud-assembly-schema@45.2.0': {}
+  '@aws-cdk/cloud-assembly-schema@48.4.0': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -1777,17 +1777,17 @@ snapshots:
 
   '@babel/compat-data@7.28.0': {}
 
-  '@babel/core@7.28.0':
+  '@babel/core@7.28.3':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helpers': 7.28.3
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1
@@ -1797,19 +1797,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.28.0':
+  '@babel/generator@7.28.3':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.28.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.1
+      browserslist: 4.25.3
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -1817,17 +1817,17 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1839,112 +1839,112 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.2':
+  '@babel/helpers@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
 
-  '@babel/parser@7.28.0':
+  '@babel/parser@7.28.3':
     dependencies:
       '@babel/types': 7.28.2
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
 
-  '@babel/traverse@7.28.0':
+  '@babel/traverse@7.28.3':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
       debug: 4.4.1
@@ -1962,9 +1962,9 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.32.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0)':
     dependencies:
-      eslint: 9.32.0
+      eslint: 9.33.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1977,9 +1977,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.3.0': {}
+  '@eslint/config-helpers@0.3.1': {}
 
-  '@eslint/core@0.15.1':
+  '@eslint/core@0.15.2':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -1997,13 +1997,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.32.0': {}
+  '@eslint/js@9.33.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 
-  '@eslint/plugin-kit@0.3.4':
+  '@eslint/plugin-kit@0.3.5':
     dependencies:
-      '@eslint/core': 0.15.1
+      '@eslint/core': 0.15.2
       levn: 0.4.1
 
   '@humanfs/core@0.19.1': {}
@@ -2032,27 +2032,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -2077,7 +2077,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -2095,7 +2095,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2116,8 +2116,8 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 22.17.0
+      '@jridgewell/trace-mapping': 0.3.30
+      '@types/node': 22.17.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -2127,7 +2127,7 @@ snapshots:
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.7
+      istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       jest-worker: 29.7.0
@@ -2144,7 +2144,7 @@ snapshots:
 
   '@jest/source-map@29.6.3':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.30
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
@@ -2164,9 +2164,9 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.30
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -2187,28 +2187,28 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@jridgewell/gen-mapping@0.3.12':
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.30
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.5.4': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.29':
+  '@jridgewell/trace-mapping@0.3.30':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2222,10 +2222,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@orcabus/platform-cdk-constructs@0.0.57(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@orcabus/platform-cdk-constructs@0.0.64(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      '@aws-cdk/aws-lambda-python-alpha': 2.208.0-alpha.0(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      '@aws-cdk/aws-lambda-python-alpha': 2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
   '@sinclair/typebox@0.27.8': {}
@@ -2248,7 +2248,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
@@ -2260,7 +2260,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
 
   '@types/babel__traverse@7.28.0':
@@ -2271,7 +2271,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -2290,7 +2290,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@22.17.0':
+  '@types/node@22.17.2':
     dependencies:
       undici-types: 6.21.0
 
@@ -2302,15 +2302,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.9.2))(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.40.0(@typescript-eslint/parser@8.40.0(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.38.0
-      eslint: 9.32.0
+      '@typescript-eslint/parser': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.40.0
+      '@typescript-eslint/type-utils': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.40.0
+      eslint: 9.33.0
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -2319,56 +2319,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.40.0(eslint@9.33.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/scope-manager': 8.40.0
+      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.40.0
       debug: 4.4.1
-      eslint: 9.32.0
+      eslint: 9.33.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.38.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.40.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.40.0
       debug: 4.4.1
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.38.0':
+  '@typescript-eslint/scope-manager@8.40.0':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/visitor-keys': 8.40.0
 
-  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.40.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.40.0(eslint@9.33.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
       debug: 4.4.1
-      eslint: 9.32.0
+      eslint: 9.33.0
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.38.0': {}
+  '@typescript-eslint/types@8.40.0': {}
 
-  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.40.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/visitor-keys': 8.38.0
+      '@typescript-eslint/project-service': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/visitor-keys': 8.40.0
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -2379,20 +2379,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.38.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.40.0(eslint@9.33.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0)
-      '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
-      eslint: 9.32.0
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.33.0)
+      '@typescript-eslint/scope-manager': 8.40.0
+      '@typescript-eslint/types': 8.40.0
+      '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
+      eslint: 9.33.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.38.0':
+  '@typescript-eslint/visitor-keys@8.40.0':
     dependencies:
-      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/types': 8.40.0
       eslint-visitor-keys: 4.2.1
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -2437,24 +2437,24 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aws-cdk-lib@2.208.0(constructs@10.4.2):
+  aws-cdk-lib@2.211.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.242
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 45.2.0
+      '@aws-cdk/cloud-assembly-schema': 48.4.0
       constructs: 10.4.2
 
-  aws-cdk@2.1023.0:
+  aws-cdk@2.1025.0:
     optionalDependencies:
       fsevents: 2.3.2
 
-  babel-jest@29.7.0(@babel/core@7.28.0):
+  babel-jest@29.7.0(@babel/core@7.28.3):
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.28.0)
+      babel-preset-jest: 29.6.3(@babel/core@7.28.3)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -2478,30 +2478,30 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.0):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.3):
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.0)
+      '@babel/core': 7.28.3
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3)
 
-  babel-preset-jest@29.6.3(@babel/core@7.28.0):
+  babel-preset-jest@29.6.3(@babel/core@7.28.3):
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
 
   balanced-match@1.0.2: {}
 
@@ -2518,12 +2518,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.25.1:
+  browserslist@4.25.3:
     dependencies:
-      caniuse-lite: 1.0.30001731
-      electron-to-chromium: 1.5.194
+      caniuse-lite: 1.0.30001735
+      electron-to-chromium: 1.5.204
       node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.1)
+      update-browserslist-db: 1.1.3(browserslist@4.25.3)
 
   bs-logger@0.2.6:
     dependencies:
@@ -2541,11 +2541,11 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001731: {}
+  caniuse-lite@1.0.30001735: {}
 
-  cdk-nag@2.36.50(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.37.6(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:
@@ -2581,13 +2581,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  create-jest@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)):
+  create-jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -2620,7 +2620,7 @@ snapshots:
 
   diff@4.0.2: {}
 
-  electron-to-chromium@1.5.194: {}
+  electron-to-chromium@1.5.204: {}
 
   emittery@0.13.1: {}
 
@@ -2645,16 +2645,16 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.32.0:
+  eslint@9.33.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.33.0)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
-      '@eslint/config-helpers': 0.3.0
-      '@eslint/core': 0.15.1
+      '@eslint/config-helpers': 0.3.1
+      '@eslint/core': 0.15.2
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.32.0
-      '@eslint/plugin-kit': 0.3.4
+      '@eslint/js': 9.33.0
+      '@eslint/plugin-kit': 0.3.5
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -2885,8 +2885,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/core': 7.28.3
+      '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -2895,8 +2895,8 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/core': 7.28.3
+      '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -2917,7 +2917,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-reports@3.1.7:
+  istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
@@ -2934,7 +2934,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
@@ -2954,16 +2954,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)):
+  jest-cli@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      create-jest: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -2973,12 +2973,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)):
+  jest-config@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)):
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
+      babel-jest: 29.7.0(@babel/core@7.28.3)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -2998,8 +2998,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.17.0
-      ts-node: 10.9.2(@types/node@22.17.0)(typescript@5.9.2)
+      '@types/node': 22.17.2
+      ts-node: 10.9.2(@types/node@22.17.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3028,7 +3028,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -3038,7 +3038,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3077,7 +3077,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -3112,7 +3112,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3140,7 +3140,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -3160,15 +3160,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/generator': 7.28.0
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.28.3
+      '@babel/generator': 7.28.3
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.3)
       '@babel/types': 7.28.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -3186,7 +3186,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3205,7 +3205,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3214,17 +3214,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)):
+  jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      jest-cli: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3468,9 +3468,9 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sqs-dlq-monitoring@1.2.21(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2):
+  sqs-dlq-monitoring@1.2.21(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
   stack-utils@2.0.6:
@@ -3526,12 +3526,12 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  ts-jest@29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2)))(typescript@5.9.2):
+  ts-jest@29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2)))(typescript@5.9.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -3540,20 +3540,20 @@ snapshots:
       typescript: 5.9.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.28.3
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
+      babel-jest: 29.7.0(@babel/core@7.28.3)
       jest-util: 29.7.0
 
-  ts-node@10.9.2(@types/node@22.17.0)(typescript@5.9.2):
+  ts-node@10.9.2(@types/node@22.17.2)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.17.0
+      '@types/node': 22.17.2
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -3574,13 +3574,13 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.38.0(eslint@9.32.0)(typescript@5.9.2):
+  typescript-eslint@8.40.0(eslint@9.33.0)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.9.2))(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0)(typescript@5.9.2)
-      eslint: 9.32.0
+      '@typescript-eslint/eslint-plugin': 8.40.0(@typescript-eslint/parser@8.40.0(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.40.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.40.0(eslint@9.33.0)(typescript@5.9.2)
+      eslint: 9.33.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -3592,9 +3592,9 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  update-browserslist-db@1.1.3(browserslist@4.25.1):
+  update-browserslist-db@1.1.3(browserslist@4.25.3):
     dependencies:
-      browserslist: 4.25.1
+      browserslist: 4.25.3
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -3602,16 +3602,16 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  uv-python-lambda@0.0.7(aws-cdk-lib@2.208.0(constructs@10.4.2))(constructs@10.4.2):
+  uv-python-lambda@0.0.7(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.208.0(constructs@10.4.2)
+      aws-cdk-lib: 2.211.0(constructs@10.4.2)
       constructs: 10.4.2
 
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.30
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.208.0-alpha.0
         version: 2.208.0-alpha.0(@aws-cdk/aws-pipes-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       '@orcabus/platform-cdk-constructs':
-        specifier: 0.0.64
-        version: 0.0.64(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
+        specifier: 0.0.66
+        version: 0.0.66(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
         specifier: ^2.211.0
         version: 2.211.0(constructs@10.4.2)
@@ -446,11 +446,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@orcabus/platform-cdk-constructs@0.0.64':
-    resolution: {integrity: sha512-itHdLe+0n7aP/SokDCgqzoCIWRmI6+dhFyyQQl43Z52uy4kKwHz1VBpihfmv9bhGHE0gRZc8LoR0l7HveSf7GA==}
+  '@orcabus/platform-cdk-constructs@0.0.66':
+    resolution: {integrity: sha512-4nkp+16lGk694C90zRg/esgsHFpw6QWoEBp0hAwkk9L9kbYKQRKV/N5mVEjLF5pwg1Xzqjg/tR6xLh2cQWdY6A==}
     peerDependencies:
-      '@aws-cdk/aws-lambda-python-alpha': ^2.208.0-alpha.0
-      aws-cdk-lib: ^2.208.0
+      '@aws-cdk/aws-lambda-python-alpha': ^2.211.0-alpha.0
+      aws-cdk-lib: ^2.211.0
       constructs: ^10.4.2
 
   '@sinclair/typebox@0.27.8':
@@ -811,8 +811,8 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
-  electron-to-chromium@1.5.204:
-    resolution: {integrity: sha512-s9VbBXWxfDrl67PlO4avwh0/GU2vcwx8Fph3wlR8LJl7ySGYId59EFE17VWVcuC3sLWNPENm6Z/uGqKbkPCcXA==}
+  electron-to-chromium@1.5.206:
+    resolution: {integrity: sha512-/eucXSTaI8L78l42xPurxdBzPTjAkMVCQO7unZCWk9LnZiwKcSvQUhF4c99NWQLwMQXxjlfoQy0+8m9U2yEDQQ==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2222,7 +2222,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@orcabus/platform-cdk-constructs@0.0.64(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@orcabus/platform-cdk-constructs@0.0.66(@aws-cdk/aws-lambda-python-alpha@2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.208.0-alpha.0(aws-cdk-lib@2.211.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib: 2.211.0(constructs@10.4.2)
@@ -2521,7 +2521,7 @@ snapshots:
   browserslist@4.25.3:
     dependencies:
       caniuse-lite: 1.0.30001735
-      electron-to-chromium: 1.5.204
+      electron-to-chromium: 1.5.206
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
 
@@ -2620,7 +2620,7 @@ snapshots:
 
   diff@4.0.2: {}
 
-  electron-to-chromium@1.5.204: {}
+  electron-to-chromium@1.5.206: {}
 
   emittery@0.13.1: {}
 

--- a/test/stage.test.ts
+++ b/test/stage.test.ts
@@ -5,6 +5,7 @@ import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { StatefulApplicationStack } from '../infrastructure/stage/stateful-application-stack';
 import { getStatefulStackProps, getStatelessStackProps } from '../infrastructure/stage/config';
 import { StatelessApplicationStack } from '../infrastructure/stage/stateless-application-stack';
+import { PROD_ENVIRONMENT } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 function synthesisMessageToString(sm: SynthesisMessage): string {
   return `${sm.entry.data} [${sm.id}]`;
@@ -15,6 +16,7 @@ describe('cdk-nag-stateful-stage-stack', () => {
 
   // You should configure all stack (sateless, stateful) to be tested
   const statefulDeploy = new StatefulApplicationStack(app, 'TestStatefulDeploy', {
+    env: PROD_ENVIRONMENT,
     ...getStatefulStackProps('PROD'),
   });
 
@@ -41,6 +43,7 @@ describe('cdk-nag-stateless-stage-stack', () => {
 
   // You should configure all stack (sateless, stateful) to be tested
   const statelessDeploy = new StatelessApplicationStack(app, 'TestStatelessDeploy', {
+    env: PROD_ENVIRONMENT,
     ...getStatelessStackProps('PROD'),
   });
 

--- a/test/toolchain.test.ts
+++ b/test/toolchain.test.ts
@@ -4,15 +4,13 @@ import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { StatelessDeployStack } from '../infrastructure/toolchain/stateless-deploy-stack';
 import { synthesisMessageToString } from './utils';
 import { StatefulDeployStack } from '../infrastructure/toolchain/stateful-deploy-stack';
+import { PROD_ENVIRONMENT } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 describe('cdk-nag-stateless-toolchain-stack', () => {
   const app = new App({});
 
   const statelessStack = new StatelessDeployStack(app, 'StatelessStack', {
-    env: {
-      account: '123456789',
-      region: 'ap-southeast-2',
-    },
+    env: PROD_ENVIRONMENT,
   });
 
   Aspects.of(statelessStack).add(new AwsSolutionsChecks());
@@ -44,10 +42,7 @@ describe('cdk-nag-stateful-toolchain-stack', () => {
   const app = new App({});
 
   const statefulStack = new StatefulDeployStack(app, 'StatefulStack', {
-    env: {
-      account: '123456789',
-      region: 'ap-southeast-2',
-    },
+    env: PROD_ENVIRONMENT,
   });
 
   Aspects.of(statefulStack).add(new AwsSolutionsChecks());


### PR DESCRIPTION
Thawed files will often result in single-part files that are very large (up to 5 Gb) in size. 

Use AWS Fargate instead of AWS Lambda to download+upload the files to the destination